### PR TITLE
added support for osx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --update add iptables && rm -rf /var/cache/apk/*
+RUN apk --update add iptables bind-tools && rm -rf /var/cache/apk/*
 
 COPY ./entrypoint.sh /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --update add iptables bind-tools && rm -rf /var/cache/apk/*
+RUN apk --update add iptables && rm -rf /var/cache/apk/*
 
 COPY ./entrypoint.sh /
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
 set -e
 
-GATEWAY=$(ip route | grep '^default' | cut -d' ' -f3)
+macGateway="$(dig +short docker.for.mac.host.internal)"
+if [ -z "$macGateway" ]
+then
+    GATEWAY=$(ip route | grep '^default' | cut -d' ' -f3)
+else
+    GATEWAY=$macGateway
+fi        
 echo "Docker Host Gateway: $GATEWAY"
 
 iptables -t nat -I PREROUTING -p tcp --match multiport --dports "${PORTS:-'0:65535'}" -j DNAT --to-destination ${GATEWAY}
 iptables -t nat -I POSTROUTING -j MASQUERADE
 
-# run forever
+#run forever
 tail -f /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 set -e
 
-macGateway="$(dig +short docker.for.mac.host.internal)"
-if [ -z "$macGateway" ]
-then
-    GATEWAY=$(ip route | grep '^default' | cut -d' ' -f3)
-else
-    GATEWAY=$macGateway
-fi        
+GATEWAY=$(ip route | grep '^default' | cut -d' ' -f3)
+
+# mac specific docker gateway
+GATEWAY_MAC="$(getent hosts docker.for.mac.host.internal | cut -d' ' -f1)"
+if [ -z "$GATEWAY_MAC" ]; then
+    GATEWAY=$GATEWAY_MAC
+fi   
+
 echo "Docker Host Gateway: $GATEWAY"
 
 iptables -t nat -I PREROUTING -p tcp --match multiport --dports "${PORTS:-'0:65535'}" -j DNAT --to-destination ${GATEWAY}
 iptables -t nat -I POSTROUTING -j MASQUERADE
 
-#run forever
+# run forever
 tail -f /dev/null


### PR DESCRIPTION
Great idea with this container! Unfortunately it wasn't working for mac, so I've added a workaround that tries to resolve the `docker.for.mac.host.internal` special domain name and falls-back on the previous method if on another host. This makes for a generic way of solving this long-standing issue!