### PR TITLE
Stop container gracefully

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  dockerhost:
+    build:
+      context: .
+    cap_add: [ 'NET_ADMIN', 'NET_RAW' ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Stop gracefully
+trap : TERM INT
+
 DOCKER_HOST="$(getent hosts host.docker.internal | cut -d' ' -f1)"
 if [ ! $DOCKER_HOST ]; then
   DOCKER_HOST=$(ip route | grep '^default' | cut -d' ' -f3)
@@ -14,4 +17,4 @@ iptables -t nat -I PREROUTING -p tcp --match multiport --dports "$FORWARDING_POR
 iptables -t nat -I POSTROUTING -j MASQUERADE
 
 # run forever
-tail -f /dev/null
+tail -f /dev/null & wait

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Stop gracefully
-trap : TERM INT
-
 DOCKER_HOST="$(getent hosts host.docker.internal | cut -d' ' -f1)"
 if [ ! $DOCKER_HOST ]; then
   DOCKER_HOST=$(ip route | grep '^default' | cut -d' ' -f3)
@@ -17,4 +14,4 @@ iptables -t nat -I PREROUTING -p tcp --match multiport --dports "$FORWARDING_POR
 iptables -t nat -I POSTROUTING -j MASQUERADE
 
 # run forever
-tail -f /dev/null & wait
+trap "exit 0;" TERM INT; while true; do sleep 1d; done & wait


### PR DESCRIPTION
Hey, this is a neat project. Thanks.

One thing I noticed is when using in Docker Compose, the container takes a while to stop. Adding a trap will let bash handle the stop signal and stop the `tail` gracefully. Stops immediately now!

I also added a `docker-compose` file for testing. I can remove it though. 