### PR TITLE
Make use of apk's --no-cache instead of manual removing /var/cache/apk/*.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --update add iptables && rm -rf /var/cache/apk/*
+RUN apk --update --no-cache add iptables
 
 COPY ./entrypoint.sh /
 


### PR DESCRIPTION
Make use of apk's --no-cache instead of manual removing /var/cache/apk/*.