### PR TITLE
Set DOCKER_HOST manually to forward to arbitrary destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Docker image to forward all traffic to the docker host
 * uses dns entry `host.docker.internal` if available
 * or default gateway as docker host
 
+You can manually override the destination IP address by setting the environment variable `DOCKER_HOST`.
+This allows you to use this image to forward traffic to arbitrary destinations, not only the docker host.
+
 [![Build Status](https://travis-ci.org/qoomon/docker-host.svg?branch=master)](https://travis-ci.org/qoomon/docker-host)
 [![Docker Stars](https://img.shields.io/docker/pulls/qoomon/docker-host.svg)](https://hub.docker.com/r/qoomon/docker-host/)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 set -e
 
-DOCKER_HOST="$(getent hosts host.docker.internal | cut -d' ' -f1)"
 if [ $DOCKER_HOST ]; then
-  echo "Docker Host: $DOCKER_HOST (host.docker.internal)"
+  echo "Docker Host: $DOCKER_HOST (manual override)"
 else
-  DOCKER_HOST=$(ip -4 route show default | cut -d' ' -f3)
-  echo "Docker Host: $DOCKER_HOST (default gateway)"
+  DOCKER_HOST="$(getent hosts host.docker.internal | cut -d' ' -f1)"
+  if [ $DOCKER_HOST ]; then
+    echo "Docker Host: $DOCKER_HOST (host.docker.internal)"
+  else
+    DOCKER_HOST=$(ip -4 route show default | cut -d' ' -f3)
+    echo "Docker Host: $DOCKER_HOST (default gateway)"
+  fi
 fi
 
 FORWARDING_PORTS=${PORTS:-'0:65535'}


### PR DESCRIPTION
This PR allows you to manually override the docker host IP address by setting the DOCKER_HOST environment variable during container creation.

The purpose is to use this package to forward traffic to arbitrary destinations, not just the docker host. I am going to use it with nginx-proxy in order to proxy external webservers.