### PR TITLE
Command error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ nc -lk 5353 -u
 ## Docker Link
 Run the dockerhost container.
 ```sh
-docker run --rm \
+docker run \
   --name 'docker-host' \
   --cap-add=NET_ADMIN --cap-add=NET_RAW \
   --restart on-failure \


### PR DESCRIPTION
When I run this command from the readme:
```
docker run --rm \
  --name 'docker-host' \
  --cap-add=NET_ADMIN --cap-add=NET_RAW \
  --restart on-failure \
  -d qoomon/docker-host
```

I get: `docker: Conflicting options: --restart and --rm.`

This command works fine after removing the `--rm`, which I think should be the correct form for this command.